### PR TITLE
Add video-bounding-box-keypoint example

### DIFF
--- a/docs/examples/basic_vbbk.py
+++ b/docs/examples/basic_vbbk.py
@@ -38,7 +38,7 @@ def single_task_workflow(inputs, params):
     # the VIDEO_BOUNDING_BOX_KEYPOINT schema
     keypoint_specs = data_helper.download(params['keypoint_specs_url'])
 
-    task = Task(name="annotate_vbbk")
+    task = Task(name="annotate_vbbk", max_attempts=10)
     task_inputs = [
         df.text(params['instructions'])
     ]

--- a/docs/examples/basic_vbbk.py
+++ b/docs/examples/basic_vbbk.py
@@ -3,10 +3,12 @@ import cv2
 
 import superai_schema.universal_schema.data_types as dt
 import superai_schema.universal_schema.task_schema_functions as df
+from superai import Client
+import requests
 from superai_dataclient.data_helper import DataHelper
 
 from superai.data_program import DataProgram, Task, Project, Worker
-
+from superai.utils import load_api_key
 
 dp_definition = {
     "input_schema": dt.bundle(video_url=dt.VIDEO),
@@ -23,9 +25,9 @@ dp = DataProgram(name=DP_NAME, definition=dp_definition, add_basic_workflow=Fals
 
 
 def single_task_workflow(inputs, params):
+    client = Client(api_key=load_api_key())
     # Sign video URL if it is a datasets URL
-    data_helper = DataHelper()
-    signed_url = data_helper.get_data_url(inputs["video_url"])
+    signed_url = client.get_signed_url(inputs["video_url"]).get("signedUrl")
 
     # Get video frame rate
     vid = cv2.VideoCapture(signed_url)
@@ -36,7 +38,7 @@ def single_task_workflow(inputs, params):
     # Get keypoint specs json
     # This should contain boxChoices, keypointChoices and keypointTemplates in a form compliant with
     # the VIDEO_BOUNDING_BOX_KEYPOINT schema
-    keypoint_specs = data_helper.download(params['keypoint_specs_url'])
+    keypoint_specs = client.download_data(params["keypoint_specs_url"])
 
     task = Task(name="annotate_vbbk", max_attempts=10)
     task_inputs = [

--- a/docs/examples/basic_vbbk.py
+++ b/docs/examples/basic_vbbk.py
@@ -12,11 +12,8 @@ from superai.utils import load_api_key
 
 dp_definition = {
     "input_schema": dt.bundle(video_url=dt.VIDEO),
-    "parameter_schema": dt.bundle(
-        instructions=dt.TEXT,
-        keypoint_specs_url=dt.URL
-    ),
-    "output_schema": dt.bundle(label=dt.VIDEO_BOUNDING_BOX_KEYPOINT)
+    "parameter_schema": dt.bundle(instructions=dt.TEXT, keypoint_specs_url=dt.URL),
+    "output_schema": dt.bundle(label=dt.VIDEO_BOUNDING_BOX_KEYPOINT),
 }
 
 DP_NAME = "VideoBoundingBoxKeypoint" + str(uuid.getnode())
@@ -41,23 +38,19 @@ def single_task_workflow(inputs, params):
     keypoint_specs = client.download_data(params["keypoint_specs_url"])
 
     task = Task(name="annotate_vbbk", max_attempts=10)
-    task_inputs = [
-        df.text(params['instructions'])
-    ]
+    task_inputs = [df.text(params["instructions"])]
     task_outputs = [
         df.video_bounding_box_keypoint(
             video_url=signed_url,
             frame_rate=frames_per_sec,
-            box_choices_obj=keypoint_specs['boxChoices'],
-            keypoint_choices_obj=keypoint_specs['keypointChoices'],
-            keypoint_templates=keypoint_specs['keypointTemplates']
+            box_choices_obj=keypoint_specs["boxChoices"],
+            keypoint_choices_obj=keypoint_specs["keypointChoices"],
+            keypoint_templates=keypoint_specs["keypointTemplates"],
         )
     ]
     task.process(task_inputs, task_outputs)
 
-    return {
-        "label": task.output.get("values", [])[0].get("schema_instance")
-    }
+    return {"label": task.output.get("values", [])[0].get("schema_instance")}
 
 
 dp.add_workflow(single_task_workflow, name="basic_vbbk", default=True)
@@ -71,15 +64,17 @@ project = Project(
     name="My Facial Keypoint Project",
     params={
         "instructions": "Please track keypoints for all facial parts visible in the video. "
-                        "Detailed instructions are provided for each facial part below.",
-        "keypoint_specs_url": "https://superai-public.s3.amazonaws.com/example_imgs/vbbk/keypoint_template.json"
+        "Detailed instructions are provided for each facial part below.",
+        "keypoint_specs_url": "https://superai-public.s3.amazonaws.com/example_imgs/vbbk/keypoint_template.json",
     },
+    uuid="0563206c-6cb8-43c1-bced-36a48038af80",
 )
 
 # Submit data for labelling
 input_urls = [
     "https://superai-public.s3.amazonaws.com/example_imgs/vbbk/sample_eye_1.mp4",
-    "https://superai-public.s3.amazonaws.com/example_imgs/vbbk/sample_mouth_1.mp4"
+    # "https://superai-public.s3.amazonaws.com/example_imgs/vbbk/sample_mouth_1.mp4",
+    "data://3485/default/sample_mouth_1.mp4",
 ]
 job_inputs = [{"video_url": u} for u in input_urls]
 labels = project.process(inputs=job_inputs, worker=Worker.me, open_browser=True)

--- a/docs/examples/basic_vbbk.py
+++ b/docs/examples/basic_vbbk.py
@@ -79,5 +79,5 @@ input_urls = [
     "https://superai-public.s3.amazonaws.com/example_imgs/vbbk/sample_eye_1.mp4",
     "https://superai-public.s3.amazonaws.com/example_imgs/vbbk/sample_mouth_1.mp4"
 ]
-job_inputs = [{"video_url": u for u in input_urls}]
+job_inputs = [{"video_url": u} for u in input_urls]
 labels = project.process(inputs=job_inputs, worker=Worker.me, open_browser=True)

--- a/docs/examples/basic_vbbk.py
+++ b/docs/examples/basic_vbbk.py
@@ -1,13 +1,11 @@
 import uuid
-import cv2
 
+import cv2
 import superai_schema.universal_schema.data_types as dt
 import superai_schema.universal_schema.task_schema_functions as df
-from superai import Client
-import requests
-from superai_dataclient.data_helper import DataHelper
 
-from superai.data_program import DataProgram, Task, Project, Worker
+from superai import Client
+from superai.data_program import DataProgram, Project, Task, Worker
 from superai.utils import load_api_key
 
 dp_definition = {
@@ -55,7 +53,6 @@ def single_task_workflow(inputs, params):
 
 dp.add_workflow(single_task_workflow, name="basic_vbbk", default=True)
 
-
 # ------------------------------------------------------------------------------------
 
 # Create a project
@@ -67,14 +64,12 @@ project = Project(
         "Detailed instructions are provided for each facial part below.",
         "keypoint_specs_url": "https://superai-public.s3.amazonaws.com/example_imgs/vbbk/keypoint_template.json",
     },
-    uuid="0563206c-6cb8-43c1-bced-36a48038af80",
 )
 
 # Submit data for labelling
 input_urls = [
     "https://superai-public.s3.amazonaws.com/example_imgs/vbbk/sample_eye_1.mp4",
-    # "https://superai-public.s3.amazonaws.com/example_imgs/vbbk/sample_mouth_1.mp4",
-    "data://3485/default/sample_mouth_1.mp4",
+    "https://superai-public.s3.amazonaws.com/example_imgs/vbbk/sample_mouth_1.mp4",
 ]
 job_inputs = [{"video_url": u} for u in input_urls]
 labels = project.process(inputs=job_inputs, worker=Worker.me, open_browser=True)

--- a/docs/examples/basic_vbbk.py
+++ b/docs/examples/basic_vbbk.py
@@ -1,0 +1,83 @@
+import uuid
+import cv2
+
+import superai_schema.universal_schema.data_types as dt
+import superai_schema.universal_schema.task_schema_functions as df
+from superai_dataclient.data_helper import DataHelper
+
+from superai.data_program import DataProgram, Task, Project, Worker
+
+
+dp_definition = {
+    "input_schema": dt.bundle(video_url=dt.VIDEO),
+    "parameter_schema": dt.bundle(
+        instructions=dt.TEXT,
+        keypoint_specs_url=dt.URL
+    ),
+    "output_schema": dt.bundle(label=dt.VIDEO_BOUNDING_BOX_KEYPOINT)
+}
+
+DP_NAME = "VideoBoundingBoxKeypoint" + str(uuid.getnode())
+
+dp = DataProgram(name=DP_NAME, definition=dp_definition, add_basic_workflow=False)
+
+
+def single_task_workflow(inputs, params):
+    # Sign video URL if it is a datasets URL
+    data_helper = DataHelper()
+    signed_url = data_helper.get_data_url(inputs["video_url"])
+
+    # Get video frame rate
+    vid = cv2.VideoCapture(signed_url)
+    if not vid.isOpened():
+        raise IOError("Couldn't open video file {}".format(signed_url))
+    frames_per_sec = vid.get(cv2.CAP_PROP_FPS)
+
+    # Get keypoint specs json
+    # This should contain boxChoices, keypointChoices and keypointTemplates in a form compliant with
+    # the VIDEO_BOUNDING_BOX_KEYPOINT schema
+    keypoint_specs = data_helper.download(params['keypoint_specs_url'])
+
+    task = Task(name="annotate_vbbk")
+    task_inputs = [
+        df.text(params['instructions'])
+    ]
+    task_outputs = [
+        df.video_bounding_box_keypoint(
+            video_url=signed_url,
+            frame_rate=frames_per_sec,
+            box_choices_obj=keypoint_specs['boxChoices'],
+            keypoint_choices_obj=keypoint_specs['keypointChoices'],
+            keypoint_templates=keypoint_specs['keypointTemplates']
+        )
+    ]
+    task.process(task_inputs, task_outputs)
+
+    return {
+        "label": task.output.get("values", [])[0].get("schema_instance")
+    }
+
+
+dp.add_workflow(single_task_workflow, name="basic_vbbk", default=True)
+
+
+# ------------------------------------------------------------------------------------
+
+# Create a project
+project = Project(
+    dataprogram=dp,
+    name="My Facial Keypoint Project",
+    params={
+        "instructions": "Please track keypoints for all facial parts visible in the video. "
+                        "Detailed instructions are provided for each facial part below.",
+        "keypoint_specs_url": "https://superai-public.s3.amazonaws.com/example_imgs/vbbk/keypoint_template.json"
+    },
+)
+
+# Submit data for labelling
+input_urls = [
+    "https://superai-public.s3.amazonaws.com/example_imgs/vbbk/sample_eye_1.mp4",
+    "https://superai-public.s3.amazonaws.com/example_imgs/vbbk/sample_mouth_1.mp4"
+]
+job_inputs = [{"video_url": u for u in input_urls}]
+labels = project.process(inputs=job_inputs, worker=Worker.me, open_browser=True)

--- a/docs/examples/basic_vbbk.py
+++ b/docs/examples/basic_vbbk.py
@@ -4,9 +4,8 @@ import cv2
 import superai_schema.universal_schema.data_types as dt
 import superai_schema.universal_schema.task_schema_functions as df
 
-from superai import Client
 from superai.data_program import DataProgram, Project, Task, Worker
-from superai.utils import load_api_key
+from superai.data_program.utils import download_content, sign_url
 
 dp_definition = {
     "input_schema": dt.bundle(video_url=dt.VIDEO),
@@ -20,9 +19,8 @@ dp = DataProgram(name=DP_NAME, definition=dp_definition, add_basic_workflow=Fals
 
 
 def single_task_workflow(inputs, params):
-    client = Client(api_key=load_api_key())
     # Sign video URL if it is a datasets URL
-    signed_url = client.get_signed_url(inputs["video_url"]).get("signedUrl")
+    signed_url = sign_url(inputs["video_url"])
 
     # Get video frame rate
     vid = cv2.VideoCapture(signed_url)
@@ -33,7 +31,7 @@ def single_task_workflow(inputs, params):
     # Get keypoint specs json
     # This should contain boxChoices, keypointChoices and keypointTemplates in a form compliant with
     # the VIDEO_BOUNDING_BOX_KEYPOINT schema
-    keypoint_specs = client.download_data(params["keypoint_specs_url"])
+    keypoint_specs = download_content(params["keypoint_specs_url"])
 
     task = Task(name="annotate_vbbk", max_attempts=10)
     task_inputs = [df.text(params["instructions"])]

--- a/superai/apis/data.py
+++ b/superai/apis/data.py
@@ -1,6 +1,7 @@
-import requests
 from abc import ABC, abstractmethod
 from typing import BinaryIO, Generator, List
+
+import requests
 
 from superai.exceptions import SuperAIStorageError
 
@@ -87,8 +88,7 @@ class DataApiMixin(ABC):
 
     def get_signed_url(self, path: str, secondsTtl: int = 600) -> dict:
         """
-        Get signed url for a dataset given its path. If the path is not a proper data path returns an unsigned URL in
-        the response object
+        Get signed url for a dataset given its path.
 
         :param path: Dataset's path e.g. `"data://.."`
         :param secondsTtl: Time to live for signed url. Max is restricted to 7 days
@@ -98,25 +98,20 @@ class DataApiMixin(ABC):
                     "signedUrl": str # Signed url
                 }
         """
-        if not path.startswith("data://"):
-            return {"ownerId": -1, "path": None, "signedUrl": path}
-
         uri = f"{self.resource}/url"
         return self.request(
             uri, method="GET", query_params={"path": path, "secondsTtl": secondsTtl}, required_api_key=True
         )
 
-    def download_data(self, uri: str):
+    def download_data(self, path: str, timeout: int = 5):
         """
         Downloads data given a `"data://..."` or URL path.
 
-        :param uri: Dataset's path or URL. If the URI is a `data` path then a signed URL will be generated first. If a
-                    standard URL is passed then the `requests` library is used to load the URL and return the content
-                    using response.json()
+        :param path: Dataset's path
         :return: URL content
         """
-        signed_url = self.get_signed_url(uri) if uri.startswith("data://") else uri
-        res = requests.get(signed_url, timeout=5)
+        signed_url = self.get_signed_url(path)
+        res = requests.get(signed_url, timeout=timeout)
         if res.status_code == 200:
             return res.json()
         else:

--- a/superai/data_program/project.py
+++ b/superai/data_program/project.py
@@ -46,7 +46,7 @@ class Project:
         # If the dp_name is not specified we assume that the data programmer's intention is to create a basic data
         # program dataprogram in order to quickly check how the data annotation works. Therefore we create a dataprogram from
         # the dp_definition
-        if not self.dataprogram:
+        if not self.dataprogram and dp_definition:
             self.dataprogram = DataProgram(name=dp_name, definition=dp_definition)
 
         # TODO: 1. Load dataprogram if exists
@@ -126,7 +126,7 @@ class Project:
             )
 
         # TODO: Add parameter
-        body_json["canoticCrowd"] = True
+        body_json["canoticCrowd"] = False
 
         # TODO: Add description support in nacelle
         # if description is not None:

--- a/superai/data_program/task.py
+++ b/superai/data_program/task.py
@@ -15,9 +15,9 @@ class Worker(str, enum.Enum):
 
 
 class Task:
-    def __init__(self, name: str = None, max_retries: int = 0, max_attempts: int = None):
+    def __init__(self, name: str = None, max_attempts: int = 1):
         self.name = name or f"TaskName-{uuid.uuid5()}"
-        self.max_attempts = max_retries + 1 if not max_attempts else max_attempts
+        self.max_attempts = 1 if not max_attempts else max_attempts
         self._task_future = None
         self._task_future_result = None
 

--- a/superai/data_program/utils.py
+++ b/superai/data_program/utils.py
@@ -3,8 +3,12 @@ from functools import wraps
 from inspect import getframeinfo, stack
 from typing import Callable
 
+import requests
+
+from superai import Client
 from superai.data_program.protocol.task import _parse_args
 from superai.log import logger
+from superai.utils import load_api_key
 
 
 def parse_dp_definition(dp_definition):
@@ -12,6 +16,44 @@ def parse_dp_definition(dp_definition):
     output_schema = _parse_args(schema=dp_definition.get("output_schema")).get("schema")
     parameter_schema = _parse_args(schema=dp_definition.get("parameter_schema")).get("schema")
     return input_schema, output_schema, parameter_schema
+
+
+def sign_url(url: str, client: Client = None):
+    """
+    Get signed url for a dataset given the resource URL. If the path is not a proper data path returns an unsigned URL
+    in the response object
+
+    :param url: Request URL
+    :param client: :class:`Client <superai.client.Client>`
+    :return: Signed url
+    """
+    if url.startswith("data://"):
+        client = client if client else Client(api_key=load_api_key())
+        return client.get_signed_url(path=url).get("signedUrl")
+
+    return url
+
+
+def download_content(url: str, client: Client = None, timeout: int = 10):
+    """
+    Downloads data given a `"data://..."` or URL path.
+
+    :param url: Dataset's path or URL. If the URL is a `data` path then a signed URL will be generated first. If a
+                    standard URL is passed then the `requests` library is used to load the URL and return the content
+                    using response.json()
+    :param client: :class:`Client <superai.client.Client>`
+    :param timeout: (optional) How many seconds to wait for the server to send data before giving up, as a float.
+    :return: URL content
+    """
+    if url.startswith("data://"):
+        client = client if client else Client(api_key=load_api_key())
+        return client.download_data(url, timeout=timeout)
+
+    res = requests.get(url, timeout=timeout)
+    if res.status_code == 200:
+        return res.json()
+    else:
+        raise Exception(res.reason)
 
 
 def IgnoreInAgent(fn: Callable):


### PR DESCRIPTION
## 🛠 Changes
- Adding sample code to create a simple video-bounding-box-keypoint Data Program
- Using `Client` to generate signed URLs
- Adds a method to the client to download data and URL content
- Modified `Client.get_signed_url` to only generate a signed URL for data paths

## 🧪 How is this tested?


## 🗒️ Release Notes
- New example: creating a simple video-bounding-box-keypoint Data Program. This example also shows how to support datasets as job inputs
- Fixes a bug where Projects were annotated by bots instead of routing it to the Project owner

### User-facing change?
- [ ] No. Skip the rest of this section
- [x] Yes. Give a description of this change to be included in the release notes.

### What component(s) does this PR affect?

**Components**
- [ ] CLI
- [ ] APIs
- [ ] DataProgram SDK

**How should the PR be classified in the release notes? Choose one:**
- [ ] `breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `bug`-fix - A user-facing bug fix worth mentioning in the release notes
- [ ] `documentation` - A user-facing documentation change worth mentioning in the release notes