### PR TITLE
VBBK example: pass original url rather than signed url into task

### DIFF
--- a/docs/examples/basic_vbbk.py
+++ b/docs/examples/basic_vbbk.py
@@ -19,6 +19,8 @@ dp = DataProgram(name=DP_NAME, definition=dp_definition, add_basic_workflow=Fals
 
 
 def single_task_workflow(inputs, params):
+    video_url = inputs["video_url"]
+
     # Sign video URL if it is a datasets URL
     signed_url = sign_url(inputs["video_url"])
 
@@ -37,7 +39,7 @@ def single_task_workflow(inputs, params):
     task_inputs = [df.text(params["instructions"])]
     task_outputs = [
         df.video_bounding_box_keypoint(
-            video_url=signed_url,
+            video_url=video_url,
             frame_rate=frames_per_sec,
             box_choices_obj=keypoint_specs["boxChoices"],
             keypoint_choices_obj=keypoint_specs["keypointChoices"],


### PR DESCRIPTION
## 🛠 Changes
- Amend VBBK example code so that we pass the original url, rather than the signed url, into task

## 🧪 How is this tested?


## 🗒️ Release Notes
- Small bug fix in video bounding box keypoint example

### User-facing change?
- [x] No. Skip the rest of this section
- [ ] Yes. Give a description of this change to be included in the release notes.

### What component(s) does this PR affect?

**Components**
- [ ] CLI
- [ ] APIs
- [ ] DataProgram SDK

**How should the PR be classified in the release notes? Choose one:**
- [ ] `breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `bug`-fix - A user-facing bug fix worth mentioning in the release notes
- [ ] `documentation` - A user-facing documentation change worth mentioning in the release notes